### PR TITLE
Add php8.1 test in GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,7 @@ jobs:
           - windows-latest
 
         php:
-          - "7.3"
-          - "7.4"
-          - "8.0"
+          - "8.1"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# Changed log

- Since this repository requires `^8.1` version at least, it's time to remove from `7.3` to `8.0` versions now.
- Adding the `php8.1` version test on GitHub workflows.